### PR TITLE
feat: add machine type change in parts editor

### DIFF
--- a/src-tauri/src/project_reader.rs
+++ b/src-tauri/src/project_reader.rs
@@ -2633,7 +2633,16 @@ pub fn save_parts_data(
 
             // Update Machine parameters (SRC page)
             if let Some(machine) = part_data.machines.get(track_id) {
-                let machine_type = part_unsaved.audio_track_machine_types[track_id];
+                let new_machine_type_id: u8 = match machine.machine_type.as_str() {
+                    "Static" => 0,
+                    "Flex" => 1,
+                    "Thru" => 2,
+                    "Neighbor" => 3,
+                    "Pickup" => 4,
+                    _ => part_unsaved.audio_track_machine_types[track_id],
+                };
+                part_unsaved.audio_track_machine_types[track_id] = new_machine_type_id;
+                let machine_type = new_machine_type_id;
 
                 match machine_type {
                     0 | 1 => {

--- a/src/components/PartsPanel.css
+++ b/src/components/PartsPanel.css
@@ -208,6 +208,27 @@
   letter-spacing: 0.5px;
 }
 
+.machine-type-select {
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  background: #1a1a1a;
+  border: 1px solid #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+  padding: 3px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  appearance: auto;
+  outline: none;
+}
+
+.machine-type-select:focus {
+  border-color: #fbbf24;
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.3);
+}
+
 .parts-params-section {
   margin-bottom: 10px;
   overflow: hidden;

--- a/src/components/PartsPanel.tsx
+++ b/src/components/PartsPanel.tsx
@@ -7,6 +7,33 @@ import { WriteStatus, writeStatus } from '../types/writeStatus';
 import { RotaryKnob } from './RotaryKnob';
 import './PartsPanel.css';
 
+const MACHINE_TYPES = ['Static', 'Flex', 'Thru', 'Neighbor', 'Pickup'] as const;
+
+function defaultMachineParams(type: string) {
+  if (type === 'Thru') {
+    return { ptch: null, strt: null, len: null, rate: null, rtrg: null, rtim: null, in_ab: 0, vol_ab: 100, in_cd: 0, vol_cd: 100, dir: null, gain: null, op: null };
+  }
+  if (type === 'Neighbor') {
+    return { ptch: null, strt: null, len: null, rate: null, rtrg: null, rtim: null, in_ab: null, vol_ab: null, in_cd: null, vol_cd: null, dir: null, gain: null, op: null };
+  }
+  if (type === 'Pickup') {
+    return { ptch: 64, strt: null, len: 127, rate: null, rtrg: null, rtim: null, in_ab: null, vol_ab: null, in_cd: null, vol_cd: null, dir: 0, gain: 64, op: 0 };
+  }
+  // Static / Flex
+  return { ptch: 64, strt: 0, len: 127, rate: 64, rtrg: 0, rtim: 127, in_ab: null, vol_ab: null, in_cd: null, vol_cd: null, dir: null, gain: null, op: null };
+}
+
+function defaultMachineSetup(type: string) {
+  if (type === 'Pickup') {
+    return { xloop: null, slic: null, len: null, rate: null, tstr: 0, tsns: 64 };
+  }
+  if (type === 'Thru' || type === 'Neighbor') {
+    return { xloop: null, slic: null, len: null, rate: null, tstr: null, tsns: null };
+  }
+  // Static / Flex
+  return { xloop: 0, slic: 0, len: 127, rate: 64, tstr: 0, tsns: 64 };
+}
+
 interface PartsPanelProps {
   projectPath: string;
   bankId: string;
@@ -457,6 +484,43 @@ export default function PartsPanel({
     });
   }, [projectPath, bankId, partNames, onWriteStatusChange]);
 
+  const updateMachineType = useCallback((partId: number, trackId: number, newType: string) => {
+    const partIndex = partsData.findIndex(p => p.part_id === partId);
+    if (partIndex === -1) return;
+
+    const updatedPart = JSON.parse(JSON.stringify(partsData[partIndex])) as PartData;
+    const machine = updatedPart.machines[trackId];
+    if (!machine) return;
+
+    machine.machine_type = newType;
+    machine.machine_params = defaultMachineParams(newType);
+    machine.machine_setup = defaultMachineSetup(newType);
+
+    setPartsData(prev => {
+      const newData = [...prev];
+      newData[partIndex] = updatedPart;
+      partsDataRef.current = newData;
+      return newData;
+    });
+
+    setModifiedPartIds(prev => new Set([...prev, partId]));
+
+    onWriteStatusChange?.(writeStatus.writing());
+    invoke('save_parts', {
+      path: projectPath,
+      bankId: bankId,
+      partsData: [updatedPart],
+    }).then(() => {
+      const partName = partNames[partId] || `Part ${partId + 1}`;
+      onWriteStatusChange?.(writeStatus.success(`Part ${partName} saved as *`));
+      setTimeout(() => onWriteStatusChange?.(writeStatus.idle()), 2000);
+    }).catch(err => {
+      console.error('Failed to save machine type change:', err);
+      onWriteStatusChange?.(writeStatus.error('Save failed'));
+      setTimeout(() => onWriteStatusChange?.(writeStatus.idle()), 3000);
+    });
+  }, [projectPath, bankId, partsData, partNames, onWriteStatusChange]);
+
   // Render param with rotary knob for All view
   const renderParamWithKnob = (
     partId: number,
@@ -591,6 +655,19 @@ export default function PartsPanel({
     return setupMappings[fxType] || ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'];
   };
 
+  const renderMachineTypeControl = (partId: number, machine: { track_id: number; machine_type: string }) =>
+    isEditMode ? (
+      <select
+        className="machine-type-select"
+        value={machine.machine_type}
+        onChange={e => updateMachineType(partId, machine.track_id, e.target.value)}
+      >
+        {MACHINE_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+      </select>
+    ) : (
+      <span className="machine-type">{machine.machine_type}</span>
+    );
+
   // Helper function to render SRC section content (MAIN + SETUP)
   const renderSrcSectionContent = (activePart: PartData, machine: typeof activePart.machines[0]) => (
     <div className="params-vertical-layout">
@@ -667,7 +744,7 @@ export default function PartsPanel({
             <div key={machine.track_id} className="parts-individual-section">
               <div className="parts-track-header">
                 <TrackBadge trackId={machine.track_id} />
-                <span className="machine-type">{machine.machine_type}</span>
+                {renderMachineTypeControl(activePart.part_id, machine)}
               </div>
               {renderSrcSectionContent(activePart, machine)}
             </div>
@@ -683,7 +760,7 @@ export default function PartsPanel({
           <div key={machine.track_id} className="parts-track">
             <div className="parts-track-header">
               <TrackBadge trackId={machine.track_id} />
-              <span className="machine-type">{machine.machine_type}</span>
+              {renderMachineTypeControl(activePart.part_id, machine)}
             </div>
 
             <div className="parts-params-section">


### PR DESCRIPTION
## Summary

- Adds a dropdown in the SRC tab (edit mode) to switch a track's machine type between Static, Flex, Thru, Neighbor, and Pickup
- Resets `machine_params` and `machine_setup` to type-appropriate defaults on change
- Saves immediately (not debounced) since it's a structural change, not a knob drag
- Dropdown styled to match the existing editable field treatment (dark bg + amber border)

## Changes

- **`src-tauri/src/project_reader.rs`**: Parse incoming machine type string and write it back to `audio_track_machine_types[track_id]` before selecting which params union to write
- **`src/components/PartsPanel.tsx`**: Add `MACHINE_TYPES`, `defaultMachineParams`, `defaultMachineSetup`, `updateMachineType`, and `renderMachineTypeControl`
- **`src/components/PartsPanel.css`**: Style `.machine-type-select` to match editable param fields

## Test plan

- [ ] Open a project and navigate to Parts Editor
- [ ] Enable Edit Mode
- [ ] On the SRC tab, confirm the machine type shows as a dropdown
- [ ] Switch from Static → Thru and verify Thru params (IN AB/CD, VOL AB/CD) appear
- [ ] Switch to Neighbor and verify no params shown
- [ ] Switch to Pickup and verify Pickup params appear
- [ ] Reload the project and confirm the machine type persisted to the bank file

🤖 Generated with [Claude Code](https://claude.com/claude-code)