### PR TITLE
Ad-hoc sign the macOS bundle so Gatekeeper stops flagging it as damaged

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,8 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "minimumSystemVersion": "10.13"
+      "minimumSystemVersion": "10.13",
+      "signingIdentity": "-"
     }
   },
   "plugins": {

--- a/user-guide/docs/getting-started/installation.md
+++ b/user-guide/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ Choose the file that matches your operating system below.
 ## macOS
 
 :::caution Important Note for Mac Users
-Octatrack Manager is not yet "signed" with an Apple Developer certificate. This means macOS will block it by default unless you follow these specific steps.
+Octatrack Manager is not signed with an Apple Developer certificate. macOS will block the first launch, and you need to approve the app manually — a one-time step described below.
 :::
 
 1. **Download:** Get the `.dmg` file for your Mac:
@@ -30,18 +30,20 @@ Octatrack Manager is not yet "signed" with an Apple Developer certificate. This 
 
 2. **Install:** Open the `.dmg` file and drag **Octatrack Manager** into your **Applications** folder.
 
-3. **Bypass Gatekeeper:**
-   - Open your **Applications** folder in Finder.
-   - **Right-click** (or Control-click) on Octatrack Manager.
-   - Select **Open** from the menu.
-   - A dialog will appear warning you about the unidentified developer. Click **Open** again.
+3. **Approve the app (first launch only):**
+   - Open your **Applications** folder and double-click **Octatrack Manager**.
+   - macOS shows a warning that it could not verify the app. Click **Done** (not "Move to Trash").
+   - Open **System Settings** → **Privacy & Security**, scroll down to the **Security** section, and click **Open Anyway** next to the message about Octatrack Manager.
+   - Confirm **Open Anyway** in the dialog that appears. The app will open normally from now on.
+
+   On macOS 14 (Sonoma) and earlier, you can instead right-click Octatrack Manager in Applications, select **Open**, and click **Open** in the warning dialog.
 
    *If the app still refuses to open:*
    Open the **Terminal** app and paste this command, then press Enter:
    ```bash
    xattr -cr /Applications/octatrack-manager.app
    ```
-   This command removes the "quarantine" attribute that prevents the app from launching.
+   This command removes the "quarantine" attribute macOS places on downloaded files.
 
 ---
 


### PR DESCRIPTION
## What this fixes

On Apple Silicon the unsigned app is quarantined as "damaged" and Gatekeeper offers no Open Anyway path, so the only way in is xattr -cr in Terminal (#5). This adds ad-hoc signing to the macOS bundle (signingIdentity "-" in tauri.conf.json, the documented Tauri v2 switch), so the build carries an ad-hoc signature. With that, macOS shows the normal unverified-developer flow and the System Settings, Privacy & Security, Open Anyway path works instead of the dead-end "damaged" message. The installation docs are updated to match that flow, with the right-click Open method kept for Sonoma and earlier.

Ad-hoc signing does not notarize the app, so the first launch still needs the one-time Open Anyway approval. Silent launch would need a paid Apple Developer ID and notarization, which is out of scope here.

## Verification

I confirmed the signing mechanism on a minimal proxy bundle: codesign --force --deep -s - then codesign --verify --strict and spctl --assess behave as expected, and a quarantined ad-hoc-signed bundle takes the unverified-developer path rather than "damaged". I could not build the real app here (no Rust toolchain on this machine), so please confirm on your next signed macOS build that the bundle launches via Open Anyway. One thing to watch: Tauri v2 runs the signed app under hardened runtime, so if a bundled dylib trips library validation it could fail after Open Anyway. That is unlikely for this app but worth a glance on the first signed build.

Closes #5
